### PR TITLE
Expose connection to module clients.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -21,8 +21,8 @@ function _handleError(error) {
 function connect(mongoUrl, options) {
 
   return new Promise(function(resolve) {
-    connector.connectToMongo(mongoUrl, options).then(function() {
-      resolve(true);
+    connector.connectToMongo(mongoUrl, options).then(function(db) {
+      resolve(db);
     }, _handleError);
   });
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,20 +19,11 @@ function _handleError(error) {
  * @returns {bluebird|exports|module.exports}
  */
 function connect(mongoUrl, options) {
-
-  return new Promise(function(resolve) {
-    connector.connectToMongo(mongoUrl, options).then(function(db) {
-      resolve(db);
-    }, _handleError);
-  });
+   return connector.connectToMongo(mongoUrl, options);
 }
 
 function disconnect() {
-  return new Promise(function(resolve) {
-    connector.closeConnection().then(function() {
-      resolve(true);
-    }, _handleError);
-  });
+  return connector.closeConnection();
 }
 
 function getDataAccessLayer(dataset) {


### PR DESCRIPTION
## Motivation

Storage module should expose connection to be used by end user app. 
We going to move connection back to the app in separate PR. 
For the moment we want to get connection initialized back by store.

ping @darachcawley